### PR TITLE
Add get_chat_history method and display current files in memory

### DIFF
--- a/streamlit_mods/components/chat_screen/chat_screen.py
+++ b/streamlit_mods/components/chat_screen/chat_screen.py
@@ -67,7 +67,7 @@ class ChatScreen:
 
     def add_initial_message(self):
         if not self.session_state_helper.initialized:
-            self.message_helper.add_bot_message(self.init_message_content, [], [], -1)
+            self.message_helper.add_bot_message(self.init_message_content, [], -1)
             self.session_state_helper.initialized = True
 
     def init_chat_input(self):
@@ -90,9 +90,9 @@ class ChatScreen:
                     st.error("Er ging iets mis bij het versturen van de vraag.")
                     return
             with st.spinner("Antwoord aan het formuleren..."):
-                self.prepare_answer(*result, start)
+                self.prepare_answer(*result, start_time=start)
 
-    def prepare_answer(self, answer: str, citations: list[dict[str, str]], source_documents: Any, start_time: float):
+    def prepare_answer(self, answer: str, citations: list[dict[str, str]], start_time: float):
         def build_placeholder() -> tuple[DeltaGenerator, str]:
             placeholder = st.empty()
             full_answer = ""
@@ -105,5 +105,5 @@ class ChatScreen:
         placeholder, full_answer = build_placeholder()
         end = default_timer()
         time_elapsed = end - start_time
-        self.message_helper.add_bot_message(answer, citations, source_documents, time_elapsed)
+        self.message_helper.add_bot_message(content=answer, citations=citations, time=time_elapsed)
         self.display_ai_message(full_answer, citations, time_elapsed, placeholder, len(self.message_helper.messages) - 1)

--- a/streamlit_mods/components/chat_screen/chat_screen.py
+++ b/streamlit_mods/components/chat_screen/chat_screen.py
@@ -7,7 +7,6 @@ from streamlit_mods.helpers.file_helper import FileState
 from typing import Any, cast
 import streamlit as st
 from streamlit.delta_generator import DeltaGenerator
-from streamlit.runtime.uploaded_file_manager import UploadedFile
 from timeit import default_timer
 import time
 

--- a/streamlit_mods/components/chat_screen/sidebar.py
+++ b/streamlit_mods/components/chat_screen/sidebar.py
@@ -1,6 +1,8 @@
+from typing import cast
 from ...helpers.session_state_helper import SessionStateHelper
 from streamlit.runtime.uploaded_file_manager import UploadedFile
 import streamlit as st
+from streamlit_mods.helpers.message_type import BotMessage
 from pathlib import Path
 
 
@@ -16,6 +18,7 @@ class Sidebar:
             st.header("Chat instellingen")
             files = self.initialize_file_uploader()
             self.initialize_file_downloader(files)
+            self.display_currently_in_memory()
 
     def initialize_file_uploader(self) -> list[UploadedFile] | None:
         css = """
@@ -54,6 +57,13 @@ class Sidebar:
                 file_name=file_name,
                 mime="application/octet-stream",
             )
+
+    def display_currently_in_memory(self):
+        bot_messages: list[BotMessage] = [cast(BotMessage, message) for message in self.message_helper.messages if message["role"] == "ai"]
+        citations = set(citation["source"] for message in bot_messages for citation in message["citations"])
+        st.subheader("Bestanden in het geheugen")
+        for citation in citations:
+            st.markdown(f" - `{citation}`")
 
     def on_file_remove(self) -> None:
         new_files: list[UploadedFile] = st.session_state[self.session_state_helper.file_uploader_key]

--- a/streamlit_mods/components/login_screen/login_screen.py
+++ b/streamlit_mods/components/login_screen/login_screen.py
@@ -1,5 +1,6 @@
 import re
 import streamlit as st
+from streamlit_mods.endpoints import Endpoints
 
 from streamlit_mods.helpers.session_state_helper import SessionStateHelper
 
@@ -17,7 +18,7 @@ class LoginScreen:
             key="login_screen_uuid_input",
             placeholder="Vul hier uw UUID in.",
             max_chars=36)
-        if is_valid_uuid(uuid_value):
+        if is_valid_uuid(uuid_value) and Endpoints.identify(session_state_helper.cookie_manager, uuid_value):
             st.success("UUID is geldig.", icon="✅")
             session_state_helper.sessionId = uuid_value
             session_state_helper.authenticated = True

--- a/streamlit_mods/components/login_screen/login_screen.py
+++ b/streamlit_mods/components/login_screen/login_screen.py
@@ -21,6 +21,7 @@ class LoginScreen:
             st.success("UUID is geldig.", icon="✅")
             session_state_helper.sessionId = uuid_value
             session_state_helper.authenticated = True
+            session_state_helper.message_helper.load_messages_from_backend(session_state_helper.sessionId)
         else:
             if uuid_value == "":
                 st.warning("Vul uw UUID hierboven in.")

--- a/streamlit_mods/components/text_edit_screen/text_edit_screen.py
+++ b/streamlit_mods/components/text_edit_screen/text_edit_screen.py
@@ -11,7 +11,7 @@ from streamlit_mods.helpers.session_state_helper import SessionStateHelper
 
 class EditTaskScreen:
     def send_final_answer(self) -> None:
-            result: bool = Endpoints.send_final_answer(cast(BotMessage, self.session_state_helper.chosen_answer), CookieManager(), self.session_state_helper.sessionId)
+            result: bool = Endpoints.send_final_answer(cast(BotMessage, self.session_state_helper.chosen_answer), self.session_state_helper.cookie_manager, self.session_state_helper.sessionId)
             if result:
                 st.success("Antwoord succesvol verstuurd!", icon="✅")
             else:

--- a/streamlit_mods/endpoints.py
+++ b/streamlit_mods/endpoints.py
@@ -5,8 +5,7 @@ from typing import Any
 import streamlit as st
 from streamlit.runtime.uploaded_file_manager import UploadedFile
 from streamlit_cookies_manager import CookieManager
-
-from streamlit_mods.helpers.message_helper import BotMessage
+from streamlit_mods.helpers.message_type import BotMessage
 
 
 Result = tuple[str, list[dict[str, str]]]

--- a/streamlit_mods/endpoints.py
+++ b/streamlit_mods/endpoints.py
@@ -135,5 +135,19 @@ class Endpoints:
         except Exception as err:
             st.error(err, icon="❌")
         return False
+    
+    @staticmethod
+    def get_chat_history(cookie_manager: CookieManager, session_id: str | None = None) -> list[dict[str, Any]] | None:
+        if not cookie_manager.ready():
+            st.stop()
+        try:
+            session_id_entry = {"sessionId": session_id} if session_id else {}
+            response = requests.get(f"{backend_url}/get_chat_history", data={**session_id_entry})
+            json_response = response.json()
+            if json_response["error"] != "":
+                raise Exception(json_response["error"])
+            return json_response["result"]
+        except Exception as err:
+            st.error(err, icon="❌")
 
         

--- a/streamlit_mods/endpoints.py
+++ b/streamlit_mods/endpoints.py
@@ -9,7 +9,7 @@ from streamlit_cookies_manager import CookieManager
 from streamlit_mods.helpers.message_helper import BotMessage
 
 
-Result = tuple[str, list[dict[str, str]], Any]
+Result = tuple[str, list[dict[str, str]]]
 backend_url = os.environ.get("FLASK_URL")
 
 
@@ -96,9 +96,8 @@ class Endpoints:
                 return None
             result = json_response["result"]
             citations = result["citations"]["citations"]
-            source_docs = result["source_documents"]
             answer = result["answer"]
-            return answer, citations, source_docs
+            return answer, citations
         except Exception as err:
             st.error(err)
 

--- a/streamlit_mods/endpoints.py
+++ b/streamlit_mods/endpoints.py
@@ -123,7 +123,8 @@ class Endpoints:
             st.stop()
         try:
             session_id_entry = {"sessionId": session_id} if session_id else {}
-            response = requests.post(f"{backend_url}/submit_final_answer", data={**session_id_entry}, json=final_answer)
+            final_answer_entry = {"finalAnswer": json.dumps(final_answer)}
+            response = requests.post(f"{backend_url}/submit_final_answer", data={**session_id_entry, **final_answer_entry})
             json_response = response.json()
             if json_response["error"] != "":
                 raise Exception(json_response["error"])

--- a/streamlit_mods/helpers/message_helper.py
+++ b/streamlit_mods/helpers/message_helper.py
@@ -12,7 +12,6 @@ class Message(TypedDict):
 class BotMessage(Message):
     content: str
     citations: list[dict[str, str]]
-    sources: Any
     time: float
     
 
@@ -40,10 +39,10 @@ class MessageHelper:
             return None
         return st.session_state.messages[-1]
 
-    def add_bot_message(self, content: str, citations: list[dict[str, str]], sources: Any, time: float) -> None:
+    def add_bot_message(self, content: str, citations: list[dict[str, str]], time: float) -> None:
         self.messages = [
             *self.messages,
-            BotMessage(role="ai", content=content, citations=citations, sources=sources, time=time),
+            BotMessage(role="ai", content=content, citations=citations, time=time),
         ]
 
     def add_user_message(self, content: str) -> None:

--- a/streamlit_mods/helpers/message_helper.py
+++ b/streamlit_mods/helpers/message_helper.py
@@ -27,8 +27,8 @@ class MessageHelper:
     def messages(self) -> list[Message]:
         if "messages" in st.session_state:
             return st.session_state.messages
-        if (message_result := Endpoints.get_chat_history(self.cookie_manager, self.session_id)) is not None:
-            return message_result
+        # if (message_result := Endpoints.get_chat_history(self.cookie_manager, self.session_id)) is not None:
+        #     return message_result
         return []
 
     @messages.setter

--- a/streamlit_mods/helpers/message_helper.py
+++ b/streamlit_mods/helpers/message_helper.py
@@ -2,6 +2,8 @@ import streamlit as st
 from typing import Any, Literal, TypedDict
 from streamlit_cookies_manager import CookieManager
 
+from streamlit_mods.endpoints import Endpoints
+
 class Message(TypedDict):
     role: Literal["human"] | Literal["ai"]
     content: str
@@ -18,12 +20,15 @@ class BotMessage(Message):
 class MessageHelper:
     def __init__(self, cookie_manager: CookieManager) -> None:
         self.cookie_manager = cookie_manager
+        self.session_id = st.session_state.sessionId
         st.session_state.messages = self.messages
 
     @property
     def messages(self) -> list[Message]:
         if "messages" in st.session_state:
             return st.session_state.messages
+        if (message_result := Endpoints.get_chat_history(self.cookie_manager, self.session_id)) is not None:
+            return message_result
         return []
 
     @messages.setter

--- a/streamlit_mods/helpers/message_type.py
+++ b/streamlit_mods/helpers/message_type.py
@@ -1,0 +1,14 @@
+from typing import Any, Literal, TypedDict
+
+Role = Literal["human"] | Literal["ai"] | Literal["final"]
+
+class Message(TypedDict):
+    role: Role
+    content: str
+
+
+class BotMessage(Message):
+    content: str
+    citations: list[dict[str, str]]
+    time: float
+    


### PR DESCRIPTION
This pull request adds a new method, `get_chat_history`, to the `Endpoints` class. It also updates the `ChatScreen` class to display the currently loaded files in memory.